### PR TITLE
Fix class namespaces to conform with PSR-4 autoloading

### DIFF
--- a/app/Resources/V1/HistoryStatusResource.php
+++ b/app/Resources/V1/HistoryStatusResource.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace App\Resources\V1;
-
 
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -17,7 +15,7 @@ class HistoryStatusResource extends JsonResource
             'location' => $this->location,
             'status' => $this->status,
             'statusCode' => $this->statusCode,
-            'label' =>   date('d-m-Y H:i', strtotime($this->created)),
+            'label' => date('d-m-Y H:i', strtotime($this->created)),
             'created' => $this->createdObject,
             'updated' => $this->updatedObject,
         ];

--- a/app/Resources/V1/HistoryTotalResource.php
+++ b/app/Resources/V1/HistoryTotalResource.php
@@ -17,7 +17,7 @@ class HistoryTotalResource extends JsonResource
             'total' => $this->total,
             'created' => $this->createdObject,
             'updated' => $this->updatedObject,
-            'label' => date('H:i', $this->created->getTimestamp())
+            'label' => date('H:i', $this->created->getTimestamp()),
         ];
     }
 }

--- a/app/Resources/V1/WarningResource.php
+++ b/app/Resources/V1/WarningResource.php
@@ -11,7 +11,7 @@ class WarningResource extends JsonResource
         return [
             '_id' => ['$id' => $this->_id],
             'text' => $this->text,
-            'label' => date('H:i', $this->created->getTimestamp())
+            'label' => date('H:i', $this->created->getTimestamp()),
         ];
     }
 }


### PR DESCRIPTION
When configuring the project I noticed some Composer warnings regarding some class namespaces not conforming with PSR-4 autoloading rules. This was due to the fact that their namespaces were referencing the folder `v1` as `V1`.

This PR renames the folder to `V1`, effectively fixing the issue.