### PR TITLE
fix(geojson-filter): Added missing cast on active

### DIFF
--- a/app/Http/Controllers/IncidentController.php
+++ b/app/Http/Controllers/IncidentController.php
@@ -32,7 +32,7 @@ class IncidentController extends Controller
             $limit = 300;
         }
 
-        $geoJson = $request->get('geojson');
+        $geoJson = filter_var($request->get('geojson'), FILTER_VALIDATE_BOOLEAN);;
 
         $csv = $request->get('csv');
         $csv2 = $request->get('csv2');


### PR DESCRIPTION
Added missing cast on active endpoint of
IncidentsController.

Without this the validation `else if($geoJson)` was always triggered
even when the the value was false.

So if user requestes the following endpoint `/v2/incidents/active?geojson=false` was returning a FeatureCollection instead the default json response.

Signed-off-by: Rubem Mota <rubemmota89@gmail.com>