### PR TITLE
docs(incident): add missing params active incident

### DIFF
--- a/docs/api.yaml
+++ b/docs/api.yaml
@@ -76,4 +76,3 @@ paths:
     $ref: './fires/paths/v2-active.yaml'
   /v2/incidents/search:
     $ref: './fires/paths/v2-search.yaml'
-

--- a/docs/fires/parameters/query/concelho-optional.yaml
+++ b/docs/fires/parameters/query/concelho-optional.yaml
@@ -1,0 +1,6 @@
+name: concelho
+in: query
+description: The municipality name
+required: false
+schema:
+  type: string

--- a/docs/fires/parameters/query/csv.yaml
+++ b/docs/fires/parameters/query/csv.yaml
@@ -1,0 +1,6 @@
+name: csv
+in: query
+description: Set true if you want the results exported as csv
+required: false
+schema:
+  type: bool

--- a/docs/fires/parameters/query/csv2.yaml
+++ b/docs/fires/parameters/query/csv2.yaml
@@ -1,0 +1,6 @@
+name: csv2
+in: query
+description: Set true if you want the results exported as csv
+required: false
+schema:
+  type: bool

--- a/docs/fires/parameters/query/fma.yaml
+++ b/docs/fires/parameters/query/fma.yaml
@@ -1,0 +1,6 @@
+name: fma
+in: query
+description: Set true if you want all incidents marked as adverse weather phenomenon
+required: false
+schema:
+  type: bool

--- a/docs/fires/parameters/query/limit.yaml
+++ b/docs/fires/parameters/query/limit.yaml
@@ -1,0 +1,5 @@
+name: limit
+in: query
+description: Number of results
+schema:
+  type: integer

--- a/docs/fires/parameters/query/otherFires.yaml
+++ b/docs/fires/parameters/query/otherFires.yaml
@@ -1,0 +1,6 @@
+name: otherFires
+in: query
+description: Checks for fires other than wildfires
+required: false
+schema:
+  type: bool

--- a/docs/fires/paths/v2-active.yaml
+++ b/docs/fires/paths/v2-active.yaml
@@ -9,7 +9,7 @@ get:
     - $ref: '../parameters/query/concelho-optional.yaml'
     - $ref: '../parameters/query/limit.yaml'
     - $ref: '../parameters/query/fma.yaml'
-    - $ref: '../parameters/query/otherFire.yaml'
+    - $ref: '../parameters/query/otherFires.yaml'
     - $ref: '../parameters/query/csv.yaml'
     - $ref: '../parameters/query/csv2.yaml'
   responses:

--- a/docs/fires/paths/v2-active.yaml
+++ b/docs/fires/paths/v2-active.yaml
@@ -6,6 +6,12 @@ get:
   parameters:
     - $ref: '../parameters/query/all.yaml'
     - $ref: '../parameters/query/geojson.yaml'
+    - $ref: '../parameters/query/concelho-optional.yaml'
+    - $ref: '../parameters/query/limit.yaml'
+    - $ref: '../parameters/query/fma.yaml'
+    - $ref: '../parameters/query/otherFire.yaml'
+    - $ref: '../parameters/query/csv.yaml'
+    - $ref: '../parameters/query/csv2.yaml'
   responses:
     200:
       $ref: '../responses/legacy-fires-list.yaml'


### PR DESCRIPTION
Updated active endpoints documentation to include the limit/fma/otherFires parameters. That are present on the controller method but don't exists on the openapi documentation